### PR TITLE
chore(config): update chest tab count in params.ini

### DIFF
--- a/config/params.ini
+++ b/config/params.ini
@@ -4,7 +4,7 @@
 profiles=general,barb,druid,necro,rogue,sorc,uniques,sigils
 ; weather to run vision mode on startup or not
 run_vision_mode_on_startup=True
-; How many tabs should be checked for items in chest. Note: All 5 Tabs must be unlocked!
+; How many tabs should be checked for items in chest. Note: All 6 Tabs must be unlocked!
 check_chest_tabs=2
 ; Transparancy of the overlay when not hovering it (has a 3 second dealy after hovering)
 ; The "shown" transparncy is 0.94


### PR DESCRIPTION
Fixes a typo in params.ini, updating the number of tabs to check for items in the chest. Now correctly indicates that all 6 tabs must be unlocked.